### PR TITLE
Allow non administration user to access integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,9 @@ url: https://github.com/matt8707/addon-ha-fusion
 # icon for the menu panel integration
 panel_icon: mdi:atom
 
+# allow non administration user to access integration
+panel_admin: false
+
 # security profile
 apparmor: true
 


### PR DESCRIPTION
to also give (for example family) users who are not administrator users acccess too Fusion via the sidepanel